### PR TITLE
feat: Add MarketDataSource entity with agent-guided configuration

### DIFF
--- a/.claude/commands/build-market-source.md
+++ b/.claude/commands/build-market-source.md
@@ -1,0 +1,15 @@
+---
+description: Configure a market data source with guided setup, progress tracking, and status updates.
+---
+
+Use the market-data-source-builder skill to help the user configure a market data source.
+
+Start by asking which provider they want to set up (Oanda, Interactive Brokers, Alpaca, Binance, etc.) and guide them through the complete configuration process with:
+
+1. Progress indicators at each step
+2. Real-time status updates
+3. Clear explanations of requirements
+4. Connection testing and validation
+5. Troubleshooting for any issues
+
+If the user mentions a specific provider or has an error, start from the appropriate phase.

--- a/.claude/skills/market-data-source-builder.md
+++ b/.claude/skills/market-data-source-builder.md
@@ -1,0 +1,352 @@
+---
+description: Helps users configure market data sources step-by-step with progress tracking, status updates, and explanations.
+---
+
+# Market Data Source Builder Skill
+
+You are a market data source configuration assistant who helps users set up, debug, and optimize their financial data providers.
+
+## Your Role
+
+- Guide users through source configuration step-by-step
+- Explain provider requirements and best practices
+- Provide real-time progress and status updates
+- Debug connection issues with clear explanations
+- Suggest optimizations for data fetching
+
+## Supported Providers
+
+| Provider | Authentication | Instruments | Notes |
+|----------|----------------|-------------|-------|
+| Oanda | API Key + Account ID | Forex, CFDs | Practice/Live environments |
+| Interactive Brokers | Client ID + Gateway | Stocks, Options, Futures | Requires TWS/Gateway |
+| Alpaca | API Key + Secret | US Stocks | Paper/Live trading |
+| Binance | API Key + Secret | Crypto | Multiple networks |
+| Coinbase | API Key + Secret | Crypto | OAuth also supported |
+| Yahoo Finance | None (public) | Stocks, ETFs | Rate limited |
+| Polygon | API Key | Stocks, Options, Forex | Tiered plans |
+
+## Configuration Process
+
+### Phase 1: Provider Selection
+
+Ask the user which provider they want to configure:
+
+**Example questions:**
+- Which market data provider would you like to configure?
+- Do you already have API credentials for this provider?
+- Will this be for practice/paper trading or live data?
+
+### Phase 2: Credentials Setup
+
+Guide the user through obtaining and entering credentials:
+
+```markdown
+## [Provider] Configuration
+
+### Step 1: Get Credentials
+
+**For Oanda:**
+1. Go to https://www.oanda.com/account/
+2. Navigate to "Manage API Access"
+3. Generate a new API token
+4. Copy your Account ID from the account summary
+
+**Required fields:**
+- API Key: `your-api-key-here`
+- Account ID: `xxx-xxx-xxxxxxxx-xxx`
+- Environment: `practice` or `live`
+```
+
+**Progress indicator:**
+```
+[■■□□□□□□□□] 20% - Credentials configured
+```
+
+### Phase 3: Instrument Selection
+
+Help the user select instruments:
+
+```markdown
+### Step 2: Select Instruments
+
+**Available for Oanda:**
+- Major Pairs: EUR_USD, GBP_USD, USD_JPY, USD_CHF
+- Minor Pairs: EUR_GBP, EUR_CHF, GBP_JPY
+- Exotic Pairs: USD_MXN, USD_ZAR
+- Commodities: XAU_USD, XAG_USD, BCO_USD
+
+**Selected instruments:** EUR_USD, GBP_USD
+
+**Tip:** Start with fewer instruments to test the connection before adding more.
+```
+
+**Progress indicator:**
+```
+[■■■■□□□□□□] 40% - Instruments selected
+```
+
+### Phase 4: Timeframe Configuration
+
+Configure data timeframes:
+
+```markdown
+### Step 3: Configure Timeframes
+
+**Available timeframes:**
+- Tick data (S5, S10, S15, S30)
+- Minutes (M1, M2, M4, M5, M10, M15, M30)
+- Hours (H1, H2, H3, H4, H6, H8, H12)
+- Daily/Weekly (D, W, M)
+
+**Selected:** M1, H1, D
+
+**Note:** More timeframes = more API calls. Consider your rate limits.
+```
+
+**Progress indicator:**
+```
+[■■■■■■□□□□] 60% - Timeframes configured
+```
+
+### Phase 5: Connection Test
+
+Test the connection before saving:
+
+```markdown
+### Step 4: Test Connection
+
+**Testing Oanda API connection...**
+
+✓ Authentication successful
+✓ Account ID valid (Practice Account)
+✓ Account balance: $100,000.00
+✓ Instruments accessible: 120 available
+✓ Rate limit: 100 requests/minute
+
+**Connection test passed!**
+```
+
+**Progress indicator:**
+```
+[■■■■■■■■□□] 80% - Connection verified
+```
+
+### Phase 6: Save and Activate
+
+Create the source:
+
+```markdown
+### Step 5: Create Source
+
+**Creating market data source...**
+
+✓ Source "Oanda Practice" created (ID: abc-123-def)
+✓ Configuration saved
+✓ Source activated
+
+**Your market data source is ready!**
+
+**Next steps:**
+1. Click "Fetch Data" to retrieve historical data
+2. Set up a schedule for automatic updates
+3. Monitor the status in the dashboard
+```
+
+**Progress indicator:**
+```
+[■■■■■■■■■■] 100% - Source created and active
+```
+
+## Status Updates
+
+When reporting status, use this format:
+
+```markdown
+## Source Status: [Name]
+
+**Provider:** Oanda
+**Environment:** Practice
+**Status:** ● Active
+
+### Connection
+- Last tested: 2 minutes ago
+- Response time: 145ms
+- Authentication: Valid
+
+### Data Fetching
+- Last fetch: 5 minutes ago
+- Records fetched: 1,500
+- Duration: 3.2s
+
+### Rate Limits
+- Used: 45/100 requests
+- Resets in: 15 seconds
+
+### Recent Activity
+| Time | Event | Status |
+|------|-------|--------|
+| 14:30 | Fetch EUR_USD H1 | ✓ Success |
+| 14:29 | Fetch EUR_USD D | ✓ Success |
+| 14:28 | Connection test | ✓ Passed |
+```
+
+## Debugging Connection Issues
+
+When users report issues, follow this process:
+
+### Step 1: Identify the Error
+
+```markdown
+## Connection Debug
+
+**Error:** Authentication failed (401 Unauthorized)
+
+**Possible causes:**
+1. Invalid API key
+2. Expired credentials
+3. Wrong environment (practice vs live)
+4. IP restriction on API key
+```
+
+### Step 2: Guided Resolution
+
+```markdown
+### Let's fix this
+
+**Check 1:** API Key Format
+- Your key should start with your account ID
+- Format: `xxx-xxx-xxxxxxxx-xxx`
+- Does your key match this pattern? ✓
+
+**Check 2:** Environment Match
+- Your source: `live`
+- Your API key type: `practice`
+- ⚠️ **Mismatch detected!**
+
+**Solution:** Change environment to `practice` or generate a live API key.
+```
+
+### Step 3: Verify Fix
+
+```markdown
+**Testing with updated configuration...**
+
+✓ Authentication successful!
+✓ Issue resolved
+
+Your connection is now working.
+```
+
+## Optimization Suggestions
+
+Proactively suggest optimizations:
+
+```markdown
+## Performance Recommendations
+
+Based on your configuration, I recommend:
+
+### 1. Reduce API Calls
+**Current:** 50 instruments × 5 timeframes = 250 calls/update
+**Suggested:** Focus on 10 key instruments = 50 calls/update
+**Savings:** 80% reduction in API usage
+
+### 2. Batch Requests
+Group instruments by timeframe to reduce overhead:
+- All M1 data in one batch
+- All H1 data in one batch
+
+### 3. Use Streaming (if available)
+For real-time data, switch from polling to streaming:
+- Lower latency
+- Fewer API calls
+- More efficient for active trading
+
+### 4. Schedule Off-Peak
+Run large data fetches during off-market hours:
+- Oanda: Sunday 5pm - Friday 5pm EST
+- Best time: Sunday evening or Friday after close
+```
+
+## Interaction Guidelines
+
+### Do:
+- Provide step-by-step guidance with progress indicators
+- Explain why each step is important
+- Show real-time status updates
+- Offer specific troubleshooting steps
+- Suggest best practices and optimizations
+- Use checkmarks (✓) and warnings (⚠️) for clarity
+
+### Don't:
+- Ask for sensitive credentials to display them back
+- Skip validation steps
+- Provide vague error messages
+- Ignore rate limit considerations
+- Suggest configurations that exceed plan limits
+
+## Example Interaction
+
+**User:** "Help me set up an Oanda data source"
+
+**Builder:**
+> Great! Let's configure your Oanda market data source. I'll guide you through each step with progress updates.
+>
+> **First, a few questions:**
+>
+> 1. Do you have an Oanda account and API credentials?
+> 2. Is this for practice (demo) or live trading?
+> 3. Which instruments do you want to track? (e.g., EUR_USD, GBP_USD)
+
+**User:** "I have a practice account. I want EUR_USD with daily timeframe."
+
+**Builder:**
+> Perfect! Let's set this up.
+>
+> ```
+> [■□□□□□□□□□] 10% - Starting configuration
+> ```
+>
+> ### Step 1: Enter Credentials
+>
+> Please provide:
+> - **API Key:** (from Oanda Account → Manage API Access)
+> - **Account ID:** (format: xxx-xxx-xxxxxxxx-xxx)
+>
+> **Tip:** Your API key and Account ID are different values. The Account ID is shown on your account summary page.
+
+[Continue through all phases with progress updates]
+
+## API Integration
+
+When creating sources via API, use this format:
+
+```json
+{
+  "name": "Oanda Practice",
+  "provider": "oanda",
+  "environment": "practice",
+  "api_key": "***-***-*******-***",
+  "account_id": "xxx-xxx-xxxxxxxx-xxx",
+  "instruments": ["EUR_USD", "GBP_USD"],
+  "timeframes": ["D"],
+  "rate_limit": 100,
+  "is_active": true
+}
+```
+
+Endpoint: `POST /api/market-data-sources/`
+
+## Quality Checklist
+
+Before finalizing configuration:
+
+- [ ] Credentials are valid and properly formatted
+- [ ] Environment matches credential type (practice/live)
+- [ ] Instruments are available for this provider
+- [ ] Timeframes are supported
+- [ ] Rate limits are considered
+- [ ] Connection test passed
+- [ ] Source is activated
+- [ ] User understands next steps

--- a/specs/entities.json
+++ b/specs/entities.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "entities": [
     {
+      "id": "raw_data_source",
       "name": "RawDataSource",
       "description": "External data source configuration for ingestion pipelines",
       "layer": "infrastructure",
@@ -132,6 +133,214 @@
         "list_fields": ["name", "source_type", "sync_status", "last_sync_at"],
         "search_fields": ["name"],
         "filter_fields": ["source_type", "is_active", "sync_status"]
+      }
+    },
+    {
+      "id": "market_data_source",
+      "name": "MarketDataSource",
+      "description": "Market data provider configuration for financial data ingestion",
+      "layer": "infrastructure",
+      "fields": [
+        {
+          "name": "id",
+          "type": "uuid",
+          "primary_key": true,
+          "description": "Unique identifier"
+        },
+        {
+          "name": "name",
+          "type": "string",
+          "required": true,
+          "max_length": 100,
+          "description": "Human-readable name for the market data source"
+        },
+        {
+          "name": "provider",
+          "type": "enum",
+          "required": true,
+          "values": ["oanda", "interactive_brokers", "alpaca", "binance", "coinbase", "yahoo_finance", "polygon", "custom"],
+          "description": "Market data provider"
+        },
+        {
+          "name": "api_key",
+          "type": "string",
+          "required": false,
+          "sensitive": true,
+          "description": "API key for authentication"
+        },
+        {
+          "name": "api_secret",
+          "type": "string",
+          "required": false,
+          "sensitive": true,
+          "description": "API secret for authentication"
+        },
+        {
+          "name": "account_id",
+          "type": "string",
+          "required": false,
+          "description": "Account/Practice account ID"
+        },
+        {
+          "name": "environment",
+          "type": "enum",
+          "required": true,
+          "default": "practice",
+          "values": ["practice", "live"],
+          "description": "Trading environment"
+        },
+        {
+          "name": "base_url",
+          "type": "string",
+          "required": false,
+          "description": "Custom API base URL"
+        },
+        {
+          "name": "instruments",
+          "type": "json",
+          "required": false,
+          "description": "List of instruments to fetch (e.g., ['EUR_USD', 'GBP_USD'])"
+        },
+        {
+          "name": "timeframes",
+          "type": "json",
+          "required": false,
+          "description": "List of timeframes to fetch (e.g., ['M1', 'H1', 'D'])"
+        },
+        {
+          "name": "rate_limit",
+          "type": "integer",
+          "required": false,
+          "default": 100,
+          "min": 1,
+          "description": "API requests per minute limit"
+        },
+        {
+          "name": "is_active",
+          "type": "boolean",
+          "required": true,
+          "default": true,
+          "description": "Whether the source is currently active"
+        },
+        {
+          "name": "last_fetch_at",
+          "type": "datetime",
+          "required": false,
+          "description": "Timestamp of last successful data fetch"
+        },
+        {
+          "name": "fetch_status",
+          "type": "enum",
+          "required": true,
+          "default": "pending",
+          "values": ["pending", "fetching", "success", "failed", "rate_limited"],
+          "description": "Current fetch status"
+        },
+        {
+          "name": "records_fetched",
+          "type": "integer",
+          "required": false,
+          "default": 0,
+          "description": "Total records fetched in last sync"
+        },
+        {
+          "name": "error_message",
+          "type": "string",
+          "required": false,
+          "description": "Last error message if fetch failed"
+        },
+        {
+          "name": "metadata",
+          "type": "json",
+          "required": false,
+          "description": "Additional provider-specific configuration"
+        },
+        {
+          "name": "created_at",
+          "type": "datetime",
+          "required": true,
+          "auto_now_add": true,
+          "description": "Creation timestamp"
+        },
+        {
+          "name": "updated_at",
+          "type": "datetime",
+          "required": true,
+          "auto_now": true,
+          "description": "Last update timestamp"
+        }
+      ],
+      "indexes": [
+        {
+          "fields": ["name"],
+          "unique": true
+        },
+        {
+          "fields": ["provider", "is_active"]
+        },
+        {
+          "fields": ["fetch_status"]
+        },
+        {
+          "fields": ["environment"]
+        }
+      ],
+      "api": {
+        "generate": true,
+        "endpoints": ["list", "get", "create", "update", "delete"],
+        "custom_endpoints": [
+          {
+            "name": "fetch",
+            "method": "POST",
+            "path": "/{id}/fetch",
+            "description": "Trigger manual data fetch from this source"
+          },
+          {
+            "name": "test_connection",
+            "method": "POST",
+            "path": "/{id}/test",
+            "description": "Test API connection and credentials"
+          },
+          {
+            "name": "get_instruments",
+            "method": "GET",
+            "path": "/{id}/instruments",
+            "description": "Get available instruments from this provider"
+          },
+          {
+            "name": "get_status",
+            "method": "GET",
+            "path": "/{id}/status",
+            "description": "Get detailed status and statistics"
+          }
+        ]
+      },
+      "ui": {
+        "icon": "candlestick-chart",
+        "color": "#10B981",
+        "list_fields": ["name", "provider", "environment", "fetch_status", "last_fetch_at"],
+        "search_fields": ["name", "provider"],
+        "filter_fields": ["provider", "is_active", "fetch_status", "environment"],
+        "actions": [
+          {
+            "name": "Fetch Data",
+            "icon": "download",
+            "endpoint": "fetch",
+            "confirm": false
+          },
+          {
+            "name": "Test Connection",
+            "icon": "plug",
+            "endpoint": "test_connection",
+            "confirm": false
+          },
+          {
+            "name": "View Instruments",
+            "icon": "list",
+            "endpoint": "get_instruments",
+            "confirm": false
+          }
+        ]
       }
     }
   ]

--- a/specs/workbenches.json
+++ b/specs/workbenches.json
@@ -254,6 +254,233 @@
         { "key": "ctrl+s", "action": "Save", "description": "Save current item" },
         { "key": "escape", "action": "Close", "description": "Close modal/panel" }
       ]
+    },
+    {
+      "name": "MarketDataSourceWorkbench",
+      "persona": "data-engineer",
+      "description": "Manage market data providers and financial data sources",
+      "entity": "MarketDataSource",
+      "theme": {
+        "primary_color": "#10B981",
+        "icon": "candlestick-chart"
+      },
+      "sections": {
+        "header": {
+          "show_breadcrumbs": true,
+          "show_persona_switcher": true,
+          "global_actions": [
+            {
+              "name": "New Provider",
+              "icon": "plus",
+              "type": "modal",
+              "shortcut": "n"
+            },
+            {
+              "name": "Import Config",
+              "icon": "upload",
+              "type": "modal"
+            },
+            {
+              "name": "Export All",
+              "icon": "download",
+              "type": "export"
+            }
+          ]
+        },
+        "data_sources": {
+          "position": "sidebar",
+          "show_status": true,
+          "show_last_sync": true,
+          "allow_multi_select": true,
+          "filters": ["provider", "environment", "fetch_status", "is_active"]
+        },
+        "quick_actions": {
+          "position": "top",
+          "actions": [
+            {
+              "name": "Fetch Data",
+              "icon": "download",
+              "type": "api_call",
+              "endpoint": "/api/market-data-sources/{id}/fetch",
+              "shortcut": "f"
+            },
+            {
+              "name": "Test Connection",
+              "icon": "plug",
+              "type": "api_call",
+              "endpoint": "/api/market-data-sources/{id}/test",
+              "shortcut": "t"
+            },
+            {
+              "name": "View Instruments",
+              "icon": "list",
+              "type": "api_call",
+              "endpoint": "/api/market-data-sources/{id}/instruments",
+              "shortcut": "i"
+            },
+            {
+              "name": "View Status",
+              "icon": "activity",
+              "type": "api_call",
+              "endpoint": "/api/market-data-sources/{id}/status",
+              "shortcut": "s"
+            }
+          ]
+        },
+        "canvas": {
+          "layout": "split-horizontal",
+          "read": {
+            "width": "55%",
+            "components": [
+              {
+                "type": "data_table",
+                "title": "Market Data Sources",
+                "entity": "MarketDataSource",
+                "config": {
+                  "columns": ["name", "provider", "environment", "fetch_status", "last_fetch_at", "records_fetched"],
+                  "row_actions": ["edit", "delete", "fetch", "test"],
+                  "bulk_actions": ["fetch", "activate", "deactivate", "delete"],
+                  "pagination": true,
+                  "page_size": 20
+                }
+              },
+              {
+                "type": "preview",
+                "title": "Available Instruments",
+                "config": {
+                  "show_instruments": true,
+                  "show_timeframes": true,
+                  "max_rows": 100
+                }
+              }
+            ]
+          },
+          "write": {
+            "width": "45%",
+            "components": [
+              {
+                "type": "form",
+                "title": "Provider Configuration",
+                "entity": "MarketDataSource",
+                "config": {
+                  "mode": "create_edit",
+                  "sections": [
+                    {
+                      "name": "Basic Info",
+                      "fields": ["name", "provider", "environment", "is_active"]
+                    },
+                    {
+                      "name": "Authentication",
+                      "fields": ["api_key", "api_secret", "account_id"]
+                    },
+                    {
+                      "name": "Data Selection",
+                      "fields": ["instruments", "timeframes"],
+                      "display": "multi_select"
+                    },
+                    {
+                      "name": "Settings",
+                      "fields": ["base_url", "rate_limit", "metadata"]
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        "agent": {
+          "position": "sidebar",
+          "width": "320px",
+          "capabilities": ["suggest", "generate", "explain", "debug", "optimize", "build_source"],
+          "context_aware": true,
+          "show_suggestions": true,
+          "auto_complete": true,
+          "prompts": [
+            {
+              "name": "Setup Oanda",
+              "description": "Help me configure an Oanda data source",
+              "template": "I want to set up an Oanda market data source for {instruments} with {timeframes} timeframe(s)"
+            },
+            {
+              "name": "Debug Connection",
+              "description": "Troubleshoot connection issues",
+              "template": "Help me debug why my {provider} connection is failing with error: {error_message}"
+            },
+            {
+              "name": "Optimize Fetch",
+              "description": "Optimize data fetching performance",
+              "template": "How can I optimize fetching data from {provider} for better performance?"
+            }
+          ]
+        },
+        "explainability": {
+          "position": "panel",
+          "show_timeline": true,
+          "show_decisions": true,
+          "show_formulas": false,
+          "detail_levels": ["summary", "detailed", "technical"],
+          "event_types": [
+            "fetch_started",
+            "fetch_completed",
+            "fetch_failed",
+            "connection_tested",
+            "rate_limited",
+            "instruments_retrieved"
+          ]
+        },
+        "tools": {
+          "position": "toolbar",
+          "tools": [
+            {
+              "name": "API Explorer",
+              "icon": "globe",
+              "type": "explorer",
+              "description": "Explore provider API endpoints"
+            },
+            {
+              "name": "Instrument Finder",
+              "icon": "search",
+              "type": "search",
+              "description": "Search for available instruments"
+            },
+            {
+              "name": "Rate Monitor",
+              "icon": "activity",
+              "type": "monitor",
+              "description": "Monitor API rate limits"
+            },
+            {
+              "name": "Data Quality",
+              "icon": "check-circle",
+              "type": "validator",
+              "description": "Check data quality metrics"
+            }
+          ]
+        },
+        "tasks": {
+          "position": "sidebar",
+          "show_progress": true,
+          "show_history": true,
+          "filters": ["active", "pending", "completed", "failed", "rate_limited"]
+        },
+        "messages": {
+          "position": "toast",
+          "show_history": true,
+          "auto_dismiss": true,
+          "types": ["info", "success", "warning", "error", "rate_limit"]
+        }
+      },
+      "shortcuts": [
+        { "key": "n", "action": "New Provider", "description": "Add new market data provider" },
+        { "key": "f", "action": "Fetch", "description": "Fetch data from selected source" },
+        { "key": "t", "action": "Test", "description": "Test connection" },
+        { "key": "i", "action": "Instruments", "description": "View available instruments" },
+        { "key": "s", "action": "Status", "description": "View detailed status" },
+        { "key": "/", "action": "Search", "description": "Search sources" },
+        { "key": "?", "action": "Help", "description": "Show keyboard shortcuts" },
+        { "key": "ctrl+s", "action": "Save", "description": "Save current item" },
+        { "key": "escape", "action": "Close", "description": "Close modal/panel" }
+      ]
     }
   ]
 }

--- a/src/app/api/entities/__init__.py
+++ b/src/app/api/entities/__init__.py
@@ -1,0 +1,11 @@
+"""Entity routers."""
+
+from fastapi import APIRouter
+
+from .raw_data_source import router as raw_data_source_router
+from .market_data_source import router as market_data_source_router
+
+router = APIRouter()
+
+router.include_router(raw_data_source_router)
+router.include_router(market_data_source_router)

--- a/src/app/api/entities/market_data_source.py
+++ b/src/app/api/entities/market_data_source.py
@@ -1,0 +1,50 @@
+"""
+API routes for MarketDataSource
+Generated from specs/entities.json
+Generated at: 2025-11-23T19:24:59.550531
+"""
+
+from fastapi import APIRouter, HTTPException, Depends
+from typing import List
+
+from domain.models.market_data_source import MarketDataSource
+# from services.database import get_db
+
+router = APIRouter(prefix="/market_data_sources", tags=["MarketDataSource"])
+
+
+# CRUD Operations
+
+@router.get("/", response_model=List[MarketDataSource])
+async def list_market_data_sources(skip: int = 0, limit: int = 100):
+    """List all market_data_sources."""
+    # TODO: Implement database query
+    return []
+
+
+@router.get("/{id}", response_model=MarketDataSource)
+async def get_market_data_source(id: str):
+    """Get a market_data_source by ID."""
+    # TODO: Implement database query
+    raise HTTPException(status_code=404, detail=f"{class_name} {id} not found")
+
+
+@router.post("/", response_model=MarketDataSource, status_code=201)
+async def create_market_data_source(item: MarketDataSource):
+    """Create a new market_data_source."""
+    # TODO: Implement database insert
+    return item
+
+
+@router.put("/{id}", response_model=MarketDataSource)
+async def update_market_data_source(id: str, item: MarketDataSource):
+    """Update an existing market_data_source."""
+    # TODO: Implement database update
+    return item
+
+
+@router.delete("/{id}", status_code=204)
+async def delete_market_data_source(id: str):
+    """Delete a market_data_source."""
+    # TODO: Implement database delete
+    pass

--- a/src/app/api/entities/raw_data_source.py
+++ b/src/app/api/entities/raw_data_source.py
@@ -1,0 +1,50 @@
+"""
+API routes for RawDataSource
+Generated from specs/entities.json
+Generated at: 2025-11-23T19:24:59.550478
+"""
+
+from fastapi import APIRouter, HTTPException, Depends
+from typing import List
+
+from domain.models.raw_data_source import RawDataSource
+# from services.database import get_db
+
+router = APIRouter(prefix="/raw_data_sources", tags=["RawDataSource"])
+
+
+# CRUD Operations
+
+@router.get("/", response_model=List[RawDataSource])
+async def list_raw_data_sources(skip: int = 0, limit: int = 100):
+    """List all raw_data_sources."""
+    # TODO: Implement database query
+    return []
+
+
+@router.get("/{id}", response_model=RawDataSource)
+async def get_raw_data_source(id: str):
+    """Get a raw_data_source by ID."""
+    # TODO: Implement database query
+    raise HTTPException(status_code=404, detail=f"{class_name} {id} not found")
+
+
+@router.post("/", response_model=RawDataSource, status_code=201)
+async def create_raw_data_source(item: RawDataSource):
+    """Create a new raw_data_source."""
+    # TODO: Implement database insert
+    return item
+
+
+@router.put("/{id}", response_model=RawDataSource)
+async def update_raw_data_source(id: str, item: RawDataSource):
+    """Update an existing raw_data_source."""
+    # TODO: Implement database update
+    return item
+
+
+@router.delete("/{id}", status_code=204)
+async def delete_raw_data_source(id: str):
+    """Delete a raw_data_source."""
+    # TODO: Implement database delete
+    pass

--- a/src/domain/models/__init__.py
+++ b/src/domain/models/__init__.py
@@ -1,0 +1,9 @@
+"""Generated models from specs/entities.json"""
+
+from .raw_data_source import RawDataSource
+from .market_data_source import MarketDataSource
+
+__all__ = [
+    "RawDataSource",
+    "MarketDataSource",
+]

--- a/src/domain/models/market_data_source.py
+++ b/src/domain/models/market_data_source.py
@@ -1,0 +1,10 @@
+"""
+Generated from specs/entities.json
+Do not edit directly - changes will be overwritten
+Generated at: 2025-11-23T19:24:59.550331
+"""
+
+from pydantic import BaseModel, Field
+
+class MarketDataSource(BaseModel):
+    """Market data provider configuration for financial data ingestion"""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,8 @@
+"""Pytest configuration and fixtures."""
+
+import pytest
+import sys
+from pathlib import Path
+
+# Add src to path for imports
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))

--- a/tests/unit/entities/test_market_data_source.py
+++ b/tests/unit/entities/test_market_data_source.py
@@ -1,0 +1,14 @@
+"""
+Tests for MarketDataSource entity
+Generated from specs/entities.json
+Generated at: 2025-11-23T19:24:59.550888
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from domain.models.market_data_source import MarketDataSource
+
+
+class TestMarketDataSource:
+    """Market data provider configuration for financial data ingestion"""

--- a/tests/unit/entities/test_raw_data_source.py
+++ b/tests/unit/entities/test_raw_data_source.py
@@ -1,0 +1,14 @@
+"""
+Tests for RawDataSource entity
+Generated from specs/entities.json
+Generated at: 2025-11-23T19:24:59.550838
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from domain.models.raw_data_source import RawDataSource
+
+
+class TestRawDataSource:
+    """External data source configuration for ingestion pipelines"""


### PR DESCRIPTION
## Summary
- Added **MarketDataSource** entity to specs for managing market data providers (Oanda, Interactive Brokers, Alpaca, Binance, Coinbase, Yahoo Finance, Polygon)
- Added **MarketDataSourceWorkbench** to specs with three-zone layout, quick actions (Fetch Data, Test Connection, View Instruments), and agent integration
- Created **market-data-source-builder** skill for step-by-step guided setup with progress tracking, status updates, and debugging help
- Created **/build-market-source** command to invoke the builder skill

## Test plan
- [ ] Verify specs validate against JSON schema with `make validate`
- [ ] Run code generation with `make generate` 
- [ ] Test MarketDataSource CRUD operations via API
- [ ] Test `/build-market-source` command flow
- [ ] Verify workbench displays correctly in frontend

## Notes
- Generator produces stub models - may need generator improvements to fully populate fields from spec
- Pre-existing test import issues exist in tests/test_raw_data_source.py and tests/generators/

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)